### PR TITLE
Update pantheon.upstream.yml

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,7 +3,7 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 8.2
+php_version: 8.1
 drush_version: 8
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb


### PR DESCRIPTION
To avoid many deprecated PHP warnings, we should downgrade the PHP version of this upstream to 8.1.
![Screenshot 2025-03-24 at 11 30 33 AM](https://github.com/user-attachments/assets/8c29a711-63c8-49a2-94bf-4ee591638fc0)
